### PR TITLE
Make event's summary optional

### DIFF
--- a/tasks/calendars_statistics/models/client/events.py
+++ b/tasks/calendars_statistics/models/client/events.py
@@ -7,7 +7,7 @@ from tasks.calendars_statistics.constants import GOOGLE_API_DATETIME_RESPONSE_FO
 
 class Event(BaseModel):
     id: str
-    summary: str
+    summary: str | None = None
     start: datetime
     end: datetime
 


### PR DESCRIPTION
User can grant access only to busy time in calendar. So api will return event's data without summary field (title of event). Made it optional.