### PR TITLE
Add schedule for report building flow into prefect.yaml

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -83,3 +83,7 @@ deployments:
     job_variables: {
       image: pt-flow-image:latest
     }
+  schedules:
+    - cron: "00 * * * *"
+      timezone: "UTC"
+      active: true


### PR DESCRIPTION
Add missing schedule for `schedule_report_building` flow into prefect config.