### PR TITLE
Disconnect calendar

### DIFF
--- a/migrations/versions/f2c00f3185f7_add_calendar_disabled_flag.py
+++ b/migrations/versions/f2c00f3185f7_add_calendar_disabled_flag.py
@@ -1,0 +1,26 @@
+"""Add calendar.disabled flag
+
+Revision ID: f2c00f3185f7
+Revises: 69e5a0e4377c
+Create Date: 2025-02-24 12:54:38.536251
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f2c00f3185f7'
+down_revision: Union[str, None] = '69e5a0e4377c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("calendar", sa.Column("disabled", sa.DateTime(timezone=True), nullable=True), schema="pt")
+
+
+def downgrade() -> None:
+    op.drop_column("calendar", "disabled", schema="pt")

--- a/pt_bot/calendars/__init__.py
+++ b/pt_bot/calendars/__init__.py
@@ -3,7 +3,9 @@ from aiogram import Router
 from pt_bot.settings import Settings
 
 from .containers import CalendarContainer
-from .routers import router
+from .routers.add_calendar import router as add_calendar_router
+from .routers.disable_calendar import router as disable_calendar_router
+from .routers.menu import router as menu_router
 
 
 async def _get_container(settings: Settings) -> CalendarContainer:
@@ -17,5 +19,7 @@ async def _get_container(settings: Settings) -> CalendarContainer:
 async def get_router(settings: Settings) -> Router:
     _router = Router()
     _router.container = await _get_container(settings)
-    _router.include_router(router)
+    _router.include_router(menu_router)
+    _router.include_router(add_calendar_router)
+    _router.include_router(disable_calendar_router)
     return _router

--- a/pt_bot/calendars/constants/buttons.py
+++ b/pt_bot/calendars/constants/buttons.py
@@ -2,7 +2,14 @@ from typing import ClassVar
 
 from pt_bot.core.buttons.base import Button, ButtonGroup
 
-from ..constants.calendar_category import CalendarCategory
+from .callback_data import CalendarCategory, MenuAction
+
+
+class MenuButtons(ButtonGroup):
+    ADD_CALENDAR: ClassVar = Button(text="Add new calendar", callback_data=MenuAction.ADD_CALENDAR)
+    DISABLE_CALENDAR: ClassVar = Button(text="Disable calendar", callback_data=MenuAction.DIABLE_CALENDAR)
+
+    rows: ClassVar = (ADD_CALENDAR, DISABLE_CALENDAR)
 
 
 class CategoryButtons(ButtonGroup):

--- a/pt_bot/calendars/constants/callback_data.py
+++ b/pt_bot/calendars/constants/callback_data.py
@@ -1,6 +1,11 @@
 from enum import StrEnum, auto
 
 
+class MenuAction(StrEnum):
+    ADD_CALENDAR = auto()
+    DIABLE_CALENDAR = auto()
+
+
 class CalendarCategory(StrEnum):
     WORK = auto()
     ENTERTAINMENT = auto()

--- a/pt_bot/calendars/constants/messages.py
+++ b/pt_bot/calendars/constants/messages.py
@@ -2,8 +2,11 @@ from enum import StrEnum
 
 
 class CalendarMessages(StrEnum):
+    MENU = "Choose the action you want to do"
     REQUEST_LINK = "Send link to the calendar you want to analyze"
     CHOOSE_CATEGORY = "Coose calendars category"
+    CHOOSE_NAME = "Choose calendar to disable"
+    СALENDAR_DISABLED_SUCCESSFULLY = "Calendar disabled successfully"
     CALENDAR_ADDED_SUCCESSFULLY = "Calendar added successfully"
     INVALID_CALENDAR_LINK = "Invalid link or access to the calendar was not granted"
     CALENDAR_DUPLICATE = "You have already added this calendar before"

--- a/pt_bot/calendars/containers.py
+++ b/pt_bot/calendars/containers.py
@@ -12,7 +12,7 @@ from .services.cliens import GoogleCalendarAPIClient
 
 class CalendarContainer(containers.DeclarativeContainer):
     wiring_config = containers.WiringConfiguration(
-        modules=[
+        packages=[
             "pt_bot.calendars.routers",
         ],
     )

--- a/pt_bot/calendars/db/queries/builders.py
+++ b/pt_bot/calendars/db/queries/builders.py
@@ -63,3 +63,25 @@ class CalendarQueryBuilder:
             name=name,
             time=time,
         )
+
+    async def disable_calendar(
+        self,
+        connection: Connection,
+        *,
+        user_id: UUID,
+        calendar_name: str,
+    ) -> None:
+        await self._queries.disable_calendar(
+            connection,
+            user_id=user_id,
+            calendar_name=calendar_name,
+        )
+
+    async def get_calendar_names(
+        self,
+        connection: Connection,
+        *,
+        user_id: UUID,
+    ) -> list[str]:
+        response = await self._queries.get_calendar_names(connection, user_id=user_id)
+        return [record["name"] for record in response]

--- a/pt_bot/calendars/db/queries/sql/calendar.sql
+++ b/pt_bot/calendars/db/queries/sql/calendar.sql
@@ -36,3 +36,18 @@ SELECT
 INSERT INTO pt.schedule
 (user_id, name, time)
 VALUES (:user_id, :name, :time);
+
+-- name: disable_calendar!
+UPDATE pt.calendar
+SET disabled=now()
+WHERE 
+    user_id = :user_id AND
+    name = :calendar_name;
+
+-- name: get_calendar_names
+SELECT
+    name
+FROM pt.calendar
+WHERE
+    user_id = :user_id AND
+    disabled IS NULL;

--- a/pt_bot/calendars/db/repositories.py
+++ b/pt_bot/calendars/db/repositories.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 import asyncpg
 
-from ..constants.calendar_category import CalendarCategory
+from ..constants.callback_data import CalendarCategory
 from ..errors import CalendarDuplicateError
 from ..models.calendars import Calendar
 from ..models.schedules import Schedule
@@ -50,4 +50,19 @@ class CalendarRepository:
                 user_id=schedule.user_id,
                 name=schedule.name,
                 time=schedule.time,
+            )
+
+    async def disable_calendar(self, user_id: UUID, calendar_name: str) -> None:
+        async with self._pool.acquire() as connection:
+            await self._queries.disable_calendar(
+                connection,
+                user_id=user_id,
+                calendar_name=calendar_name,
+            )
+
+    async def get_calendar_names(self, user_id: UUID) -> list[str]:
+        async with self._pool.acquire() as connection:
+            return await self._queries.get_calendar_names(
+                connection,
+                user_id=user_id,
             )

--- a/pt_bot/calendars/fsm.py
+++ b/pt_bot/calendars/fsm.py
@@ -2,5 +2,7 @@ from aiogram.fsm.state import State, StatesGroup
 
 
 class CalendarState(StatesGroup):
-    LINK = State()
-    CATEGORY = State()
+    CHOOSE_ACTION = State()
+    PROCESS_LINK = State()
+    SET_CATEGORY = State()
+    CHOOSE_NAME = State()

--- a/pt_bot/calendars/keyboards.py
+++ b/pt_bot/calendars/keyboards.py
@@ -1,7 +1,9 @@
+from collections.abc import Iterable
+
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
-from pt_bot.core.buttons.base import ButtonGroup
+from pt_bot.core.buttons.base import Button, ButtonGroup
 from pt_bot.core.keyboards import BaseKeyboard
 
 from .constants import buttons
@@ -9,9 +11,27 @@ from .constants import buttons
 
 class CalendarKeyboard(BaseKeyboard):
     @classmethod
+    def menu_kb(
+        cls: type["CalendarKeyboard"],
+        buttons_group: ButtonGroup = buttons.MenuButtons,
+    ) -> InlineKeyboardMarkup:
+        builder = InlineKeyboardBuilder()
+        cls._add_buttons(builder, buttons_group, InlineKeyboardButton)
+        return builder.as_markup()
+
+    @classmethod
     def category_kb(
         cls: type["CalendarKeyboard"],
         buttons_group: ButtonGroup = buttons.CategoryButtons,
+    ) -> InlineKeyboardMarkup:
+        builder = InlineKeyboardBuilder()
+        cls._add_buttons(builder, buttons_group, InlineKeyboardButton)
+        return builder.as_markup()
+
+    @classmethod
+    def disable_calendar_kb(
+        cls: type["CalendarKeyboard"],
+        buttons_group: Iterable[Button],
     ) -> InlineKeyboardMarkup:
         builder = InlineKeyboardBuilder()
         cls._add_buttons(builder, buttons_group, InlineKeyboardButton)

--- a/pt_bot/calendars/routers/add_calendar.py
+++ b/pt_bot/calendars/routers/add_calendar.py
@@ -1,30 +1,33 @@
 from uuid import UUID
 
 from aiogram import Router, types
-from aiogram.filters.command import Command
 from aiogram.fsm.context import FSMContext
 from dependency_injector.wiring import Provide, inject
 
 from pt_bot.core.models.user import User
 from pt_bot.core.utils import inject_user
 
-from .constants.messages import CalendarMessages
-from .containers import CalendarContainer
-from .errors import CalendarDuplicateError, InvalidCalendarIDError
-from .fsm import CalendarState
-from .keyboards import CalendarKeyboard
-from .services.calendars import CalendarService
+from ..constants.buttons import MenuButtons
+from ..constants.messages import CalendarMessages
+from ..containers import CalendarContainer
+from ..errors import CalendarDuplicateError, InvalidCalendarIDError
+from ..fsm import CalendarState
+from ..keyboards import CalendarKeyboard
+from ..services.calendars import CalendarService
 
 router = Router()
 
 
-@router.message(Command("calendar"))
-async def calendar_command(message: types.Message, state: FSMContext) -> None:
-    await message.answer(text=CalendarMessages.REQUEST_LINK)
-    await state.set_state(CalendarState.LINK)
+@router.callback_query(lambda c: c.data == MenuButtons.ADD_CALENDAR.callback_data)
+async def request_calendar_link(
+    callback: types.CallbackQuery,
+    state: FSMContext,
+) -> None:
+    await callback.message.edit_text(text=CalendarMessages.REQUEST_LINK)
+    await state.set_state(CalendarState.PROCESS_LINK)
 
 
-@router.message(CalendarState.LINK)
+@router.message(CalendarState.PROCESS_LINK)
 @inject
 @inject_user
 async def calendar_link_processing(
@@ -45,11 +48,11 @@ async def calendar_link_processing(
         return
 
     await message.answer(text=CalendarMessages.CHOOSE_CATEGORY, reply_markup=CalendarKeyboard.category_kb())
-    await state.set_state(CalendarState.CATEGORY)
+    await state.set_state(CalendarState.SET_CATEGORY)
     await state.set_data(str(calendar_id))
 
 
-@router.callback_query(CalendarState.CATEGORY)
+@router.callback_query(CalendarState.SET_CATEGORY)
 @inject
 async def calendar_category_choice(
     callback: types.CallbackQuery,

--- a/pt_bot/calendars/routers/disable_calendar.py
+++ b/pt_bot/calendars/routers/disable_calendar.py
@@ -1,0 +1,50 @@
+from aiogram import Router, types
+from aiogram.fsm.context import FSMContext
+from dependency_injector.wiring import Provide, inject
+
+from pt_bot.core.buttons.base import Button
+from pt_bot.core.models.user import User
+from pt_bot.core.utils import inject_user
+
+from ..constants.buttons import MenuButtons
+from ..constants.messages import CalendarMessages
+from ..containers import CalendarContainer
+from ..fsm import CalendarState
+from ..keyboards import CalendarKeyboard
+from ..services.calendars import CalendarService
+
+router = Router()
+
+
+@router.callback_query(lambda c: c.data == MenuButtons.DISABLE_CALENDAR.callback_data)
+@inject
+@inject_user
+async def choose_calendar_to_disable(
+    callback: types.CallbackQuery,
+    state: FSMContext,
+    user: User,
+    calendar_service: CalendarService = Provide[CalendarContainer.calendar_service],
+) -> None:
+    calendar_names = await calendar_service.get_calendar_names(user)
+
+    buttons = [Button(text=name, callback_data=name) for name in calendar_names]
+
+    await callback.message.edit_text(
+        text=CalendarMessages.REQUEST_LINK,
+        reply_markup=CalendarKeyboard.disable_calendar_kb(buttons),
+    )
+    await state.set_state(CalendarState.CHOOSE_NAME)
+
+
+@router.callback_query(CalendarState.CHOOSE_NAME)
+@inject
+@inject_user
+async def disable_calendar(
+    callback: types.CallbackQuery,
+    state: FSMContext,
+    user: User,
+    calendar_service: CalendarService = Provide[CalendarContainer.calendar_service],
+) -> None:
+    await calendar_service.disable_calendar(user=user, calendar_name=callback.data)
+    await callback.message.edit_text(text=CalendarMessages.СALENDAR_DISABLED_SUCCESSFULLY)
+    await state.clear()

--- a/pt_bot/calendars/routers/menu.py
+++ b/pt_bot/calendars/routers/menu.py
@@ -1,0 +1,15 @@
+from aiogram import Router, types
+from aiogram.filters.command import Command
+from aiogram.fsm.context import FSMContext
+
+from ..constants.messages import CalendarMessages
+from ..fsm import CalendarState
+from ..keyboards import CalendarKeyboard
+
+router = Router()
+
+
+@router.message(Command("calendar"))
+async def show_menu(message: types.Message, state: FSMContext) -> None:
+    await message.answer(text=CalendarMessages.MENU, reply_markup=CalendarKeyboard.menu_kb())
+    await state.set_state(CalendarState.CHOOSE_ACTION)

--- a/pt_bot/calendars/services/calendars.py
+++ b/pt_bot/calendars/services/calendars.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from pt_bot.core.models.user import User
 
-from ..constants.calendar_category import CalendarCategory
+from ..constants.callback_data import CalendarCategory
 from ..db.repositories import CalendarRepository
 from ..models.schedules import DefaultWeeklyReportSchedule
 from .cliens import GoogleCalendarAPIClient
@@ -29,3 +29,12 @@ class CalendarService:
 
     async def update_calendar_category(self, calendar_id: UUID, calendar_category: CalendarCategory) -> None:
         await self._calendar.update_calendar_category(calendar_id, calendar_category)
+
+    async def disable_calendar(self, user: User, calendar_name: str) -> None:
+        await self._calendar.disable_calendar(
+            user_id=user.id,
+            calendar_name=calendar_name,
+        )
+
+    async def get_calendar_names(self, user: User) -> list[str]:
+        return await self._calendar.get_calendar_names(user.id)

--- a/pt_bot/core/containers.py
+++ b/pt_bot/core/containers.py
@@ -12,7 +12,7 @@ from .services.user import UserService
 
 class CoreContainer(containers.DeclarativeContainer):
     wiring_config = containers.WiringConfiguration(
-        modules=[
+        packages=[
             "pt_bot.calendars.routers",
         ],
     )

--- a/tasks/calendars_statistics/db/queries/sql/calendar.sql
+++ b/tasks/calendars_statistics/db/queries/sql/calendar.sql
@@ -9,7 +9,7 @@ VALUES (
 
 -- name: get_calendars_to_parse
 WITH calendars_with_daily_statistics AS (
-    SELECT s.calendar_id
+    SELECT DISTINCT s.calendar_id
     FROM pt.statistics s
     WHERE s.date = :filter_date
 )
@@ -21,8 +21,9 @@ SELECT
     c.timezone,
     cc.name AS category
 FROM pt.calendar c
-JOIN pt.calendar_category cc on c.category = cc.id
+JOIN pt.calendar_category cc ON c.category = cc.id
 LEFT JOIN calendars_with_daily_statistics cds ON c.id = cds.calendar_id
 WHERE 
     c.timezone = ANY(:timezones) AND
+    c.disabled IS NULL AND
     cds.calendar_id IS NULL;

--- a/tasks/reports/db/queries/sql/report.sql
+++ b/tasks/reports/db/queries/sql/report.sql
@@ -44,7 +44,7 @@ SELECT
     name
 FROM pt.calendar
 WHERE 
-    user_id = :user_id;
+    user_id = :user_id AND disabled IS NULL;
 
 
 -- name: get_statistics_extremums^

--- a/tests/pt_bot/unit/calendars/mocks/repositories.py
+++ b/tests/pt_bot/unit/calendars/mocks/repositories.py
@@ -1,6 +1,6 @@
 from uuid import UUID, uuid4
 
-from pt_bot.calendars.constants.calendar_category import CalendarCategory
+from pt_bot.calendars.constants.callback_data import CalendarCategory
 from pt_bot.calendars.errors import CalendarDuplicateError
 from pt_bot.calendars.models.calendars import Calendar
 from pt_bot.calendars.models.schedules import Schedule

--- a/tests/pt_bot/unit/calendars/test_calendar_service.py
+++ b/tests/pt_bot/unit/calendars/test_calendar_service.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pt_bot.calendars.constants.calendar_category import CalendarCategory
+from pt_bot.calendars.constants.callback_data import CalendarCategory
 from pt_bot.calendars.errors import CalendarDuplicateError, InvalidCalendarIDError
 from pt_bot.calendars.models.calendars import Calendar
 from pt_bot.calendars.models.schedules import DefaultWeeklyReportSchedule


### PR DESCRIPTION
# Overview
Add `calendar.disabled` to skip some calendars before statistics parsing and don't show them in report.
Refactored calandar routers. Made a simple button menu.

## Telegram
Added command to disable any connected calendar using telegram bot. It will save `datetime with time zone` in this new column. By default it is `null`.