### PR TITLE
Retry some http errors from google calendar api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "freezegun>=1.5.1",
     "pygal>=3.0.5",
     "jinja2>=3.1.4",
+    "tenacity>=9.0.0",
 ]
 
 [tool.ruff]

--- a/tests/tasks/unit/calendars_statistics/conftest.py
+++ b/tests/tasks/unit/calendars_statistics/conftest.py
@@ -7,6 +7,7 @@ from tasks.calendars_statistics.constants import GOOGLE_API_DATETIME_RESPONSE_FO
 from tasks.calendars_statistics.containers import CalendarsStatisticsContainer
 from tasks.calendars_statistics.models.calendars import Calendar
 from tasks.calendars_statistics.models.client.events import Event
+from tasks.calendars_statistics.models.flows_params import StatisticsFilters
 from tasks.calendars_statistics.services.statistics import StatisticsService
 from tasks.settings import Settings
 
@@ -39,6 +40,7 @@ def google_id() -> str:
 @pytest.fixture
 def calendar(google_id: str) -> Calendar:
     return Calendar(
+        id=uuid4(),
         google_id=google_id,
         name="test_calendar_name",
         timezone="Etc/UTC",
@@ -61,3 +63,13 @@ def calendar_events() -> list[Event]:
             end={"dateTime": format_dt(now)},
         ),
     ]
+
+
+@pytest.fixture
+def filters(calendar: Calendar):
+    return StatisticsFilters(
+        calendar_id=calendar.id,
+        calendar_google_id=calendar.google_id,
+        start=datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=1),
+        end=datetime.datetime.now(tz=datetime.UTC),
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1264,6 +1264,7 @@ dependencies = [
     { name = "pytest-asyncio" },
     { name = "redis" },
     { name = "ruff" },
+    { name = "tenacity" },
 ]
 
 [package.metadata]
@@ -1285,6 +1286,7 @@ requires-dist = [
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "redis", specifier = ">=5.2.0" },
     { name = "ruff", specifier = ">=0.7.1" },
+    { name = "tenacity", specifier = ">=9.0.0" },
 ]
 
 [[package]]
@@ -1961,6 +1963,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3e/da/1fb4bdb72ae12b834becd7e1e7e47001d32f91ec0ce8d7bc1b618d9f0bd9/starlette-0.41.2.tar.gz", hash = "sha256:9834fd799d1a87fd346deb76158668cfa0b0d56f85caefe8268e2d97c3468b62", size = 2573867 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/43/f185bfd0ca1d213beb4293bed51d92254df23d8ceaf6c0e17146d508a776/starlette-0.41.2-py3-none-any.whl", hash = "sha256:fbc189474b4731cf30fcef52f18a8d070e3f3b46c6a04c97579e85e6ffca942d", size = 73259 },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/94/91fccdb4b8110642462e653d5dcb27e7b674742ad68efd146367da7bdb10/tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b", size = 47421 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/cb/b86984bed139586d01532a587464b5805f12e397594f19f931c4c2fbfa61/tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539", size = 28169 },
 ]
 
 [[package]]


### PR DESCRIPTION
# Overview
Handle `aiogoogle` exceptions. Add retry using `tenacity`.

## Exceptions
404 is most common in client logic. If calendar is unavailable anymore, `aiogoogle` will raise  `HTTPError` with this status code. So I added handling of `HTTPError` and any other `AiogoogleError`. By default client will return empty list and log exception using `prefect.get_run_logger()`.

## Retry
I use `tenacity` to retry request on this http codes:
- 408
- 429
- 5**

There will be 3 attempts with exponential wait + jitter.