### PR TITLE
Statistics parsing configuration

### DIFF
--- a/migrations/versions/009884f79e7c_add_statistics_parsing_config.py
+++ b/migrations/versions/009884f79e7c_add_statistics_parsing_config.py
@@ -23,8 +23,8 @@ def upgrade() -> None:
         "statistics_parsing_config",
         sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
         sa.Column("user_id", sa.UUID(), nullable=False),
-        sa.Column("skip_all_day_events", sa.Boolean(), nullable=False, default=True),
-        sa.Column("skip_rejected_meetings", sa.Boolean(), nullable=False, default=True),
+        sa.Column("skip_all_day_events", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("skip_rejected_meetings", sa.Boolean(), nullable=False, server_default="true"),
         sa.Column(
             "created_dt",
             sa.DateTime(timezone=True),

--- a/migrations/versions/009884f79e7c_add_statistics_parsing_config.py
+++ b/migrations/versions/009884f79e7c_add_statistics_parsing_config.py
@@ -1,0 +1,48 @@
+"""Add statistics parsing config
+
+Revision ID: 009884f79e7c
+Revises: f2c00f3185f7
+Create Date: 2025-02-25 15:17:03.340938
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '009884f79e7c'
+down_revision: Union[str, None] = 'f2c00f3185f7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "statistics_parsing_config",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("skip_all_day_events", sa.Boolean(), nullable=False, default=True),
+        sa.Column("skip_rejected_meetings", sa.Boolean(), nullable=False, default=True),
+        sa.Column(
+            "created_dt",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("timezone('UTC', now())"),
+            nullable=False
+        ),
+        sa.Column(
+            "updated_dt",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("timezone('UTC', now())"),
+            onupdate=sa.text("timezone('UTC', now())"),
+            nullable=False
+        ),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_statistics_parsing_config')),
+        sa.ForeignKeyConstraint(["user_id"], ["pt.user.id"], name="fk_statistics_parsing_config_user_id_user_id"),
+        schema="pt",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("statistics_parsing_config", schema="pt")

--- a/migrations/versions/009884f79e7c_add_statistics_parsing_config.py
+++ b/migrations/versions/009884f79e7c_add_statistics_parsing_config.py
@@ -43,6 +43,13 @@ def upgrade() -> None:
         schema="pt",
     )
 
+    op.execute(
+        """
+        INSERT INTO pt.statistics_parsing_config (user_id)
+        SELECT id FROM pt.user;
+        """
+    )
+
 
 def downgrade() -> None:
     op.drop_table("statistics_parsing_config", schema="pt")

--- a/pt_bot/start/db/queries/builders.py
+++ b/pt_bot/start/db/queries/builders.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 import aiosql
 from aiosql.queries import Queries as AiosqlQueries
 from asyncpg import Connection
@@ -10,8 +12,11 @@ class UserQueryBuilder:
     async def load_queries(self, path: str = "sql/", driver: str = "asyncpg") -> None:
         self._queries = aiosql.from_path(path, driver)
 
-    async def get_user_id(self, connection: Connection, tg_id: int) -> str | None:
+    async def get_user_id(self, connection: Connection, *, tg_id: int) -> str | None:
         return await self._queries.get_user_id(connection, tg_id=tg_id)
 
-    async def create_user(self, connection: Connection, tg_id: int) -> None:
-        await self._queries.create_user(connection, tg_id=tg_id)
+    async def create_user(self, connection: Connection, *, tg_id: int) -> UUID:
+        return await self._queries.create_user(connection, tg_id=tg_id)
+
+    async def create_statistics_parsing_config(self, connection: Connection, *, user_id: UUID) -> None:
+        await self._queries.create_statistics_parsing_config(connection, user_id=user_id)

--- a/pt_bot/start/db/queries/sql/user.sql
+++ b/pt_bot/start/db/queries/sql/user.sql
@@ -3,6 +3,11 @@ SELECT id
 FROM pt.user AS u
 WHERE u.telegram_id = :tg_id;
 
--- name: create_user!
+-- name: create_user<!
 INSERT INTO pt.user (telegram_id)
-VALUES (:tg_id);
+VALUES (:tg_id)
+RETURNING id;
+
+-- name: create_statistics_parsing_config!
+INSERT INTO pt.statistics_parsing_config
+(user_id) VALUES (:user_id);

--- a/pt_bot/start/db/repositories.py
+++ b/pt_bot/start/db/repositories.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 import asyncpg
 
 from ..errors import UserAlreadyExistsError
@@ -17,12 +19,16 @@ class UserRepository:
             )
             return bool(user_id)
 
-    async def create_user(self, tg_id: int) -> None:
+    async def create_user(self, tg_id: int) -> UUID:
         async with self._pool.acquire() as connection:
             try:
-                await self._queries.create_user(
+                return await self._queries.create_user(
                     connection=connection,
                     tg_id=tg_id,
                 )
             except asyncpg.exceptions.UniqueViolationError as e:
                 raise UserAlreadyExistsError(tg_id=tg_id) from e
+
+    async def create_statistics_parsing_config(self, user_id: UUID) -> None:
+        async with self._pool.acquire() as connection:
+            await self._queries.create_statistics_parsing_config(connection, user_id=user_id)

--- a/pt_bot/start/services/users.py
+++ b/pt_bot/start/services/users.py
@@ -15,4 +15,5 @@ class UserService:
 
     async def create_new_user(self, user: User) -> None:
         with contextlib.suppress(UserAlreadyExistsError):
-            await self._user.create_user(user.id)
+            user_id = await self._user.create_user(user.id)
+            await self._user.create_statistics_parsing_config(user_id)

--- a/tasks/calendars_statistics/db/queries/builders.py
+++ b/tasks/calendars_statistics/db/queries/builders.py
@@ -17,6 +17,7 @@ class CalendarQueryBuilder:
     async def save_statistics(
         self,
         connection: Connection,
+        *,
         calendar_id: UUID,
         minutes: int,
         date: date,
@@ -29,10 +30,26 @@ class CalendarQueryBuilder:
         )
 
     async def get_calendars_to_parse(
-        self, connection: Connection, timezones: Iterable[str], filter_date: date
+        self,
+        connection: Connection,
+        *,
+        timezones: Iterable[str],
+        filter_date: date,
     ) -> list[dict]:
         return await self._queries.get_calendars_to_parse(
             connection,
             timezones=timezones,
             filter_date=filter_date,
         )
+
+    async def get_statistics_parsing_config(
+        self,
+        connection: Connection,
+        *,
+        user_id: UUID,
+    ) -> dict:
+        data = await self._queries.get_statistics_parsing_config(
+            connection,
+            user_id=user_id,
+        )
+        return dict(data)

--- a/tasks/calendars_statistics/db/queries/sql/calendar.sql
+++ b/tasks/calendars_statistics/db/queries/sql/calendar.sql
@@ -15,6 +15,7 @@ WITH calendars_with_daily_statistics AS (
 )
 SELECT
     c.id,
+    c.user_id,
     c.name,
     c.description,
     c.google_id,
@@ -27,3 +28,13 @@ WHERE
     c.timezone = ANY(:timezones) AND
     c.disabled IS NULL AND
     cds.calendar_id IS NULL;
+
+
+-- name: get_statistics_parsing_config^
+SELECT
+    user_id,
+    skip_all_day_events,
+    skip_rejected_meetings
+FROM pt.statistics_parsing_config
+WHERE 
+    user_id = :user_id;

--- a/tasks/calendars_statistics/db/repositories.py
+++ b/tasks/calendars_statistics/db/repositories.py
@@ -5,6 +5,7 @@ from uuid import UUID
 import asyncpg
 
 from ..models.calendars import Calendar
+from ..models.parsing_config import StatisticsParsingConfig
 from .queries.builders import CalendarQueryBuilder
 
 
@@ -30,3 +31,8 @@ class CalendarRepository:
                 filter_date=filter_date,
             )
             return [Calendar.model_validate(dict(calendar)) for calendar in calendars]
+
+    async def get_statistics_parsing_config(self, user_id: UUID) -> StatisticsParsingConfig:
+        async with self._pool.acquire() as connection:
+            config_data = await self._queries.get_statistics_parsing_config(connection, user_id=user_id)
+            return StatisticsParsingConfig.model_validate(config_data)

--- a/tasks/calendars_statistics/flows.py
+++ b/tasks/calendars_statistics/flows.py
@@ -27,6 +27,7 @@ async def schedule_calendars_statistics_parsing() -> None:
     for calendar in calendars_to_parse:
         start, end = statistics_service.parsing_interval(calendar.timezone)
         filters = StatisticsFilters(
+            user_id=calendar.user_id,
             calendar_id=calendar.id,
             calendar_google_id=calendar.google_id,
             start=start,

--- a/tasks/calendars_statistics/models/calendars.py
+++ b/tasks/calendars_statistics/models/calendars.py
@@ -4,9 +4,10 @@ from pydantic import BaseModel
 
 
 class Calendar(BaseModel):
+    id: UUID
+    user_id: UUID
     google_id: str
     name: str
     timezone: str
-    id: UUID | None = None
     description: str | None = None
     category: str | None = None

--- a/tasks/calendars_statistics/models/client/events.py
+++ b/tasks/calendars_statistics/models/client/events.py
@@ -35,7 +35,7 @@ class MeetingResponseStatus(StrEnum):
 
 
 class Attendee(BaseModel):
-    self: bool
+    self: bool = False
     status: MeetingResponseStatus = Field(alias="responseStatus")
 
 

--- a/tasks/calendars_statistics/models/client/events.py
+++ b/tasks/calendars_statistics/models/client/events.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from enum import StrEnum
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -26,8 +27,21 @@ class DateTimeField(BaseModel):
         return dt.datetime.strptime(dt_, GOOGLE_API_DATE_RESPONSE_FORMAT).date()  # noqa: DTZ007
 
 
+class MeetingResponseStatus(StrEnum):
+    NEEDS_ACTION = "needsAction"
+    DECLINE = "declined"
+    TENTATIVE = "tentative"
+    ACCEPTED = "accepted"
+
+
+class Attendee(BaseModel):
+    self: bool
+    status: MeetingResponseStatus = Field(alias="responseStatus")
+
+
 class Event(BaseModel):
     id: str
     summary: str | None = None
+    attendees: list[Attendee] | None = None
     start: DateTimeField
     end: DateTimeField

--- a/tasks/calendars_statistics/models/flows_params.py
+++ b/tasks/calendars_statistics/models/flows_params.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 
 class StatisticsFilters(BaseModel):
+    user_id: UUID
     calendar_id: UUID
     calendar_google_id: str
     start: datetime

--- a/tasks/calendars_statistics/models/parsing_config.py
+++ b/tasks/calendars_statistics/models/parsing_config.py
@@ -1,0 +1,9 @@
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class StatisticsParsingConfig(BaseModel):
+    user_id: UUID
+    skip_all_day_events: bool
+    skip_rejected_meetings: bool

--- a/tasks/calendars_statistics/services/calendars.py
+++ b/tasks/calendars_statistics/services/calendars.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from ..db.repositories import CalendarRepository
 from ..models.calendars import Calendar
+from ..models.parsing_config import StatisticsParsingConfig
 
 
 class CalendarService:
@@ -18,3 +19,6 @@ class CalendarService:
 
     async def get_calendars_to_parse(self, timezones: Iterable[str], filter_date: date) -> list[Calendar]:
         return await self._calendar.get_calendars_to_parse(timezones=timezones, filter_date=filter_date)
+
+    async def get_statistics_parsing_config(self, user_id: UUID) -> StatisticsParsingConfig:
+        return await self._calendar.get_statistics_parsing_config(user_id)

--- a/tasks/calendars_statistics/services/clients.py
+++ b/tasks/calendars_statistics/services/clients.py
@@ -3,8 +3,8 @@ from datetime import datetime
 
 from aiogoogle import Aiogoogle, excs
 from aiogoogle.auth.creds import ServiceAccountCreds
-from prefect import get_run_logger
-from tenacity import retry, stop_after_attempt, wait_exponential_jitter
+from prefect.logging import get_run_logger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from ..constants import GOOGLE_API_DATETIME_FORMAT
 from ..models.client.events import Event
@@ -49,6 +49,7 @@ class GoogleCalendarAPIClient:
             initial=1,
             max=60,
         ),
+        retry=retry_if_exception_type(excs.HTTPError),
     )
     async def events(self, calendar_id: str, start: datetime, end: datetime) -> list[Event]:
         logger = get_run_logger()

--- a/tests/pt_bot/unit/start/mocks/repositories.py
+++ b/tests/pt_bot/unit/start/mocks/repositories.py
@@ -1,15 +1,26 @@
+from uuid import UUID, uuid4
+
 from pt_bot.start.errors import UserAlreadyExistsError
 
 
 class UserRepositoryMock:
     def __init__(self, pool=None, queries=None):
-        self._db = {}
+        self._db = {
+            "users": {},
+            "parsing_config": {},
+        }
 
     async def check_user_exists(self, tg_id: int) -> bool:
-        return tg_id in self._db
+        return tg_id in self._db["users"]
 
-    async def create_user(self, tg_id: int) -> None:
-        if tg_id in self._db:
+    async def create_user(self, tg_id: int) -> UUID:
+        if tg_id in self._db["users"]:
             raise UserAlreadyExistsError(tg_id=tg_id)
 
-        self._db[tg_id] = tg_id
+        user_id = uuid4()
+        self._db["users"][tg_id] = user_id
+        return user_id
+
+    async def create_statistics_parsing_config(self, user_id: UUID) -> None:
+        config_id = uuid4()
+        self._db["parsing_config"][user_id] = config_id

--- a/tests/pt_bot/unit/start/test_user_service.py
+++ b/tests/pt_bot/unit/start/test_user_service.py
@@ -5,22 +5,27 @@ from pt_bot.start.services.users import UserService
 
 class TestUserService:
     async def test_check_user_exists__no_user(self, user_service: UserService, telegram_user: User):
-        exists = await user_service.user_exists(telegram_user)
-        assert not exists
+        user_service._user._db["users"].clear()
+        assert not await user_service.user_exists(telegram_user)
 
     async def test_check_user_exists(self, user_service: UserService, telegram_user: User):
-        user_service._user._db[telegram_user.id] = telegram_user.id
-        exists = await user_service.user_exists(telegram_user)
-        assert exists
+        user_service._user._db["users"][telegram_user.id] = telegram_user.id
+        assert await user_service.user_exists(telegram_user)
 
     async def test_create_new_user(self, user_service: UserService, telegram_user: User):
+        user_service._user._db["users"].clear()
+        user_service._user._db["parsing_config"].clear()
+
         await user_service.create_new_user(telegram_user)
-        exists = await user_service.user_exists(telegram_user)
-        assert exists
+
+        assert user_service._user._db["users"]
+        assert user_service._user._db["parsing_config"]
 
     async def test_create_new_user__user_duplicate(self, user_service: UserService, telegram_user: User):
-        await user_service.create_new_user(telegram_user)
-        await user_service.create_new_user(telegram_user)
-        exists = await user_service.user_exists(telegram_user)
+        user_service._user._db["users"].clear()
+        user_service._user._db["parsing_config"].clear()
 
-        assert exists
+        await user_service.create_new_user(telegram_user)
+        await user_service.create_new_user(telegram_user)
+
+        assert await user_service.user_exists(telegram_user)

--- a/tests/tasks/unit/calendars_statistics/conftest.py
+++ b/tests/tasks/unit/calendars_statistics/conftest.py
@@ -8,6 +8,7 @@ from tasks.calendars_statistics.containers import CalendarsStatisticsContainer
 from tasks.calendars_statistics.models.calendars import Calendar
 from tasks.calendars_statistics.models.client.events import Event
 from tasks.calendars_statistics.models.flows_params import StatisticsFilters
+from tasks.calendars_statistics.models.parsing_config import StatisticsParsingConfig
 from tasks.calendars_statistics.services.statistics import StatisticsService
 from tasks.settings import Settings
 
@@ -41,6 +42,7 @@ def google_id() -> str:
 def calendar(google_id: str) -> Calendar:
     return Calendar(
         id=uuid4(),
+        user_id=uuid4(),
         google_id=google_id,
         name="test_calendar_name",
         timezone="Etc/UTC",
@@ -68,8 +70,18 @@ def calendar_events() -> list[Event]:
 @pytest.fixture
 def filters(calendar: Calendar):
     return StatisticsFilters(
+        user_id=calendar.user_id,
         calendar_id=calendar.id,
         calendar_google_id=calendar.google_id,
         start=datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=1),
         end=datetime.datetime.now(tz=datetime.UTC),
+    )
+
+
+@pytest.fixture
+def parsing_config(calendar: Calendar):
+    return StatisticsParsingConfig(
+        user_id=calendar.user_id,
+        skip_all_day_events=True,
+        skip_rejected_meetings=True,
     )

--- a/tests/tasks/unit/calendars_statistics/data/events.py
+++ b/tests/tasks/unit/calendars_statistics/data/events.py
@@ -1,6 +1,11 @@
 from uuid import uuid4
 
-from tasks.calendars_statistics.models.client.events import DateTimeField, Event
+from tasks.calendars_statistics.models.client.events import (
+    Attendee,
+    DateTimeField,
+    Event,
+    MeetingResponseStatus,
+)
 
 SINGE_HOUR_EVENT = [
     Event(
@@ -86,5 +91,20 @@ SINGE_HOUR_EVENT__ENDS_NEXT_DAY = [
         summary="test summary",
         start=DateTimeField(dateTime="2025-01-01T23:30:00+00:00", timeZone="Etc/UTC"),
         end=DateTimeField(dateTime="2025-01-02T00:30:00+00:00", timeZone="Etc/UTC"),
+    ),
+]
+
+SINGLE_HOUR_EVENT_WITH_REJECTED_MEETING = [
+    Event(
+        id=str(uuid4()),
+        summary="test summary",
+        start=DateTimeField(dateTime="2025-01-01T00:00:00+00:00", timeZone="Etc/UTC"),
+        end=DateTimeField(dateTime="2025-01-01T01:00:00+00:00", timeZone="Etc/UTC"),
+        attendees=[
+            Attendee(
+                self=True,
+                responseStatus=MeetingResponseStatus.DECLINE,
+            )
+        ],
     ),
 ]

--- a/tests/tasks/unit/calendars_statistics/mocks/repositories.py
+++ b/tests/tasks/unit/calendars_statistics/mocks/repositories.py
@@ -3,6 +3,7 @@ from datetime import date
 from uuid import UUID
 
 from tasks.calendars_statistics.models.calendars import Calendar
+from tasks.calendars_statistics.models.parsing_config import StatisticsParsingConfig
 
 
 class CalendarRepository:
@@ -10,6 +11,7 @@ class CalendarRepository:
         self._db = {
             "statistics": {},
             "calendars": {},
+            "parsing_config": {},
         }
 
     async def save_statistics(self, calendar_id: UUID, minutes: int, date: date) -> None:
@@ -20,3 +22,6 @@ class CalendarRepository:
 
     async def get_calendars_to_parse(self, timezones: Iterable[str], filter_date: date) -> list[Calendar]:
         return [calendar for calendar in self._db["calendars"].values() if calendar.timezone in timezones]
+
+    async def get_statistics_parsing_config(self, user_id: UUID) -> StatisticsParsingConfig:
+        return self._db["parsing_config"][user_id]


### PR DESCRIPTION
# Overview
Add opportunity to skip some types of events. Such filtering params can be individual for each user. I plan to add a command in the bot so users can modify this settings.

## Parsing config
After creating new user, bot will also add statistics parsing config. By default it is set to skip all day events and discarded meetings. This config is stored in `statistics_parsing_config` table.

## Api retry
Set param to retry only on `aiogoogle.excs.HTTPError`. Otherwise it will retry on any unhandled exception. 
